### PR TITLE
Added Cooler Lunchbox Item

### DIFF
--- a/Lunchbox/assets/lunchbox/itemtypes/cooler.json
+++ b/Lunchbox/assets/lunchbox/itemtypes/cooler.json
@@ -1,0 +1,117 @@
+{
+	"code": "cooler",
+	"creativeinventory": {
+		"general": [ "*" ],
+		"items": [ "*" ]
+	},
+	"class": "Lunchbox.LunchboxItem",
+	"behaviors": [
+		{
+			"name": "GroundStorable",
+			"properties": {
+				"layout": "SingleCenter",
+				"collisionBox": {
+					"x1": 0.25,
+					"y1": 0,
+					"z1": 0.25,
+					"x2": 0.75,
+					"y2": 0.375,
+					"z2": 0.75
+				}
+			}
+		},
+		{ "name": "Lunchbox.LunchboxBehaviour" }
+	],
+	"attributes": {
+		"defaultSpoilSpeedMult": 0.75,
+		"backpack": {
+			"quantitySlots": 4,
+			"slotBgColor": "#d9ffc2"
+		}
+	},
+	"variantgroups": [
+		{
+			"code": "wood",
+			"states": [ "aged" ],
+			"loadFromProperties": "block/wood"
+		}
+	],
+	"shape": { "base": "item/cooler" },
+	"texturesByType": {
+		"*": {
+			"wood": {
+				"base": "game:block/wood/planks/{wood}*"
+			}
+		}
+	},
+	"maxstacksize": 1,
+	"storageFlags": 2,
+	"materialDensity": 450,
+	"guiTransform": {
+		"translation": {
+			"x": 1,
+			"y": 0,
+			"z": 0
+		},
+		"rotation": {
+			"x": -21,
+			"y": 16,
+			"z": 180
+		},
+		"origin": {
+			"x": 0.52,
+			"y": 0.26,
+			"z": 0.5
+		},
+		"scale": 2.3,
+		"rotate": true
+	},
+	"fpHandTransform": {
+		"translation": {
+			"x": 0,
+			"y": 0,
+			"z": 0.3
+		},
+		"rotation": {
+			"x": 20,
+			"y": -73,
+			"z": 10
+		},
+		"scale": 1.5
+	},
+	"tpHandTransform": {
+		"translation": {
+			"x": -0.7,
+			"y": -0.7,
+			"z": -0.8
+		},
+		"rotation": {
+			"x": -19,
+			"y": 81,
+			"z": -27
+		},
+		"scale": 0.68
+	},
+	"groundTransform": {
+		"translation": {
+			"x": 0,
+			"y": 0,
+			"z": 0
+		},
+		"rotation": {
+			"x": 180,
+			"y": 33,
+			"z": -180
+		},
+		"origin": {
+			"x": 0.5,
+			"y": 0,
+			"z": 0.5
+		},
+		"scale": 3
+	},
+	"combustibleProps": {
+		"burnTemperature": 600,
+		"burnDuration": 10
+	}
+}

--- a/Lunchbox/assets/lunchbox/itemtypes/lunchbox.json
+++ b/Lunchbox/assets/lunchbox/itemtypes/lunchbox.json
@@ -39,7 +39,7 @@
 	"attributes": {
 		"backpack": {
 			"quantitySlots": 4,
-			"slotBgColor": "#c2ffe8"
+			"slotBgColor": "#e8c2ff"
 		}
 	},
 	"shape": { "base": "item/lunchbox" },

--- a/Lunchbox/assets/lunchbox/lang/en.json
+++ b/Lunchbox/assets/lunchbox/lang/en.json
@@ -1,4 +1,6 @@
 {
 	"item-lunchbox-*": "Lunchbox",
-	"itemdesc-lunchbox-*": "Stores food which will be eaten automatically when hungry."
+	"itemdesc-lunchbox-*": "Stores food which will be eaten automatically when hungry.",
+	"item-cooler-*": "Cooler",
+	"itemdesc-cooler-*": "Stores food which will be eaten automatically when hungry."
 }

--- a/Lunchbox/assets/lunchbox/lang/ja.json
+++ b/Lunchbox/assets/lunchbox/lang/ja.json
@@ -1,6 +1,8 @@
 {
 	"item-lunchbox-*": "お弁当",
-	"itemdesc-lunchbox-*": "お腹がすいた時に貯蔵食品を自動的に食べます。"
+	"itemdesc-lunchbox-*": "お腹がすいた時に貯蔵食品を自動的に食べます。",
+	"item-cooler-*": " クーラーボックス",
+	"itemdesc-cooler-*": "お腹がすいた時に貯蔵食品を自動的に食べます。"
 }
 
 

--- a/Lunchbox/assets/lunchbox/recipes/grid/cooler.json
+++ b/Lunchbox/assets/lunchbox/recipes/grid/cooler.json
@@ -1,0 +1,34 @@
+{
+  "ingredientPattern": "PIP,PGP,PMP",
+  "ingredients": {
+    "I": {
+      "type": "block",
+      "code": "game:glacierice",
+      "quantity": 3
+    },
+    "G": {
+      "type": "item",
+      "code": "game:drygrass",
+      "quantity": 5
+    },
+    "M": {
+      "type": "item",
+      "code": "game:ingot-*",
+      "allowedVariants": [ "zinc", "tin" ],
+      "quantity": 1
+    },
+    "P": {
+      "type": "item",
+      "code": "game:plank-*",
+      "name": "wood",
+      "quantity": 2
+    }
+  },
+  "width": 3,
+  "height": 3,
+  "output": {
+    "type": "item",
+    "code": "cooler-{wood}"
+  }
+}
+

--- a/Lunchbox/assets/lunchbox/shapes/item/cooler.json
+++ b/Lunchbox/assets/lunchbox/shapes/item/cooler.json
@@ -1,0 +1,181 @@
+{
+	"editor": {
+		"collapsedPaths": ",Root/W,Root/lid",
+		"allAngles": false,
+		"entityTextureMode": false
+	},
+	"textureWidth": 16,
+	"textureHeight": 16,
+	"textureSizes": {
+	},
+	"textures": {
+		"metal": "game:block/metal/ingot/zinc",
+		"wood": "game:block/wood/planks/oak1"
+	},
+	"elements": [
+		{
+			"name": "N",
+			"from": [ 4.0, 0.0, 4.0 ],
+			"to": [ 12.0, 5.0, 5.0 ],
+			"faces": {
+				"north": { "texture": "#wood", "uv": [ 3.5, 7.0, 8.5, 15.0 ], "rotation": 90 },
+				"east": { "texture": "#wood", "uv": [ 11.0, 5.0, 16.0, 6.0 ], "rotation": 90 },
+				"south": { "texture": "#wood", "uv": [ 4.0, 3.0, 9.0, 11.0 ], "rotation": 90 },
+				"west": { "texture": "#wood", "uv": [ 3.0, 4.0, 8.0, 5.0 ], "rotation": 90 },
+				"up": { "texture": "#wood", "uv": [ 2.0, 0.0, 3.0, 8.0 ], "rotation": 90 },
+				"down": { "texture": "#wood", "uv": [ 1.0, 2.5, 2.0, 10.5 ], "rotation": 90 }
+			}
+		},
+		{
+			"name": "S",
+			"from": [ 4.0, 0.0, 11.0 ],
+			"to": [ 12.0, 5.0, 12.0 ],
+			"faces": {
+				"north": { "texture": "#wood", "uv": [ 4.0, 3.0, 12.0, 8.0 ] },
+				"east": { "texture": "#wood", "uv": [ 11.0, 11.0, 16.0, 12.0 ], "rotation": 90 },
+				"south": { "texture": "#wood", "uv": [ 4.0, 4.0, 9.0, 12.0 ], "rotation": 90 },
+				"west": { "texture": "#wood", "uv": [ 3.5, 2.0, 8.5, 3.0 ], "rotation": 90 },
+				"up": { "texture": "#wood", "uv": [ 2.0, 0.0, 3.0, 8.0 ], "rotation": 90 },
+				"down": { "texture": "#wood", "uv": [ 1.0, 2.0, 2.0, 10.0 ], "rotation": 90 }
+			}
+		},
+		{
+			"name": "W",
+			"from": [ 4.0, 0.0, 5.0 ],
+			"to": [ 5.0, 5.0, 11.0 ],
+			"faces": {
+				"north": { "texture": "#basket", "uv": [ 0.0, 0.0, 1.0, 5.0 ], "enabled": false },
+				"east": { "texture": "#wood", "uv": [ 4.5, 2.0, 9.5, 8.0 ], "rotation": 90 },
+				"south": { "texture": "#basket", "uv": [ 0.0, 0.0, 1.0, 5.0 ], "enabled": false },
+				"west": { "texture": "#wood", "uv": [ 5.0, 10.0, 10.0, 16.0 ], "rotation": 90 },
+				"up": { "texture": "#wood", "uv": [ 0.0, 0.0, 6.0, 1.0 ], "rotation": 90 },
+				"down": { "texture": "#wood", "uv": [ 2.0, 2.5, 8.0, 3.5 ], "rotation": 90 }
+			},
+			"children": [
+				{
+					"name": "handle W",
+					"from": [ 0.5, 1.0, 2.5 ],
+					"to": [ 1.5, 7.5, 3.5 ],
+					"faces": {
+						"north": { "texture": "#metal", "uv": [ 4.0, 5.0, 5.0, 11.5 ] },
+						"east": { "texture": "#metal", "uv": [ 4.0, 6.0, 5.0, 12.5 ] },
+						"south": { "texture": "#metal", "uv": [ 4.0, 9.0, 5.0, 15.5 ] },
+						"west": { "texture": "#metal", "uv": [ 4.0, 9.0, 5.0, 15.5 ] },
+						"up": { "texture": "#metal", "uv": [ 4.0, 5.0, 5.0, 6.0 ] },
+						"down": { "texture": "#basket", "uv": [ 0.0, 0.0, 1.0, 1.0 ], "enabled": false }
+					}
+				},
+				{
+					"name": "handle E",
+					"from": [ 6.5, 1.0, 2.5 ],
+					"to": [ 7.5, 7.5, 3.5 ],
+					"faces": {
+						"north": { "texture": "#metal", "uv": [ 4.0, 5.0, 5.0, 11.5 ] },
+						"east": { "texture": "#metal", "uv": [ 4.0, 6.0, 5.0, 12.5 ] },
+						"south": { "texture": "#metal", "uv": [ 4.0, 9.0, 5.0, 15.5 ] },
+						"west": { "texture": "#metal", "uv": [ 4.0, 9.0, 5.0, 15.5 ] },
+						"up": { "texture": "#metal", "uv": [ 4.0, 5.0, 5.0, 6.0 ] },
+						"down": { "texture": "#basket", "uv": [ 0.0, 0.0, 1.0, 1.0 ], "enabled": false }
+					}
+				},
+				{
+					"name": "handle up",
+					"from": [ 1.5, 6.5, 2.5 ],
+					"to": [ 6.5, 7.5, 3.5 ],
+					"rotationOrigin": [ 0.0, -1.0, 0.0 ],
+					"faces": {
+						"north": { "texture": "#metal", "uv": [ 4.0, 5.0, 9.0, 6.0 ] },
+						"east": { "texture": "#metal", "uv": [ 4.0, 6.0, 5.0, 7.0 ] },
+						"south": { "texture": "#metal", "uv": [ 4.0, 9.0, 9.0, 10.0 ] },
+						"west": { "texture": "#metal", "uv": [ 4.0, 9.0, 5.0, 10.0 ] },
+						"up": { "texture": "#metal", "uv": [ 4.0, 5.0, 9.0, 6.0 ] },
+						"down": { "texture": "#metal", "uv": [ 0.0, 0.0, 5.0, 1.0 ] }
+					}
+				}
+			]
+		},
+		{
+			"name": "E",
+			"from": [ 11.0, 0.0, 5.0 ],
+			"to": [ 12.0, 5.0, 11.0 ],
+			"faces": {
+				"north": { "texture": "#basket", "uv": [ 0.0, 0.0, 1.0, 5.0 ], "enabled": false },
+				"east": { "texture": "#wood", "uv": [ 5.0, 5.0, 10.0, 11.0 ], "rotation": 90 },
+				"south": { "texture": "#basket", "uv": [ 0.0, 0.0, 1.0, 5.0 ], "enabled": false },
+				"west": { "texture": "#wood", "uv": [ 5.0, 2.0, 10.0, 8.0 ], "rotation": 90 },
+				"up": { "texture": "#wood", "uv": [ 9.0, 0.0, 15.0, 1.0 ], "rotation": 90 },
+				"down": { "texture": "#wood", "uv": [ 5.0, 2.5, 11.0, 3.5 ], "rotation": 90 }
+			}
+		},
+		{
+			"name": "floor",
+			"from": [ 5.0, 0.0, 5.0 ],
+			"to": [ 11.0, 1.0, 11.0 ],
+			"faces": {
+				"north": { "texture": "#basket", "uv": [ 0.0, 0.0, 6.0, 1.0 ], "enabled": false },
+				"east": { "texture": "#basket", "uv": [ 0.0, 0.0, 6.0, 1.0 ], "enabled": false },
+				"south": { "texture": "#basket", "uv": [ 0.0, 0.0, 6.0, 1.0 ], "enabled": false },
+				"west": { "texture": "#basket", "uv": [ 0.0, 0.0, 6.0, 1.0 ], "enabled": false },
+				"up": { "texture": "#wood", "uv": [ 5.0, 5.0, 11.0, 11.0 ] },
+				"down": { "texture": "#wood", "uv": [ 5.0, 10.0, 11.0, 16.0 ] }
+			}
+		},
+		{
+			"name": "lid",
+			"from": [ 3.5, 5.0, 4.0 ],
+			"to": [ 12.5, 6.0, 12.5 ],
+			"rotationOrigin": [ 0.0, 5.0, 0.5 ],
+			"faces": {
+				"north": { "texture": "#wood", "uv": [ 0.0, 0.0, 9.0, 1.0 ], "windMode": [-1,-1,-1,-1] },
+				"east": { "texture": "#wood", "uv": [ 0.0, 0.0, 8.5, 1.0 ], "windMode": [-1,-1,-1,-1] },
+				"south": { "texture": "#wood", "uv": [ 0.0, 0.0, 9.0, 1.0 ], "windMode": [-1,-1,-1,-1] },
+				"west": { "texture": "#wood", "uv": [ 0.0, 0.0, 8.5, 1.0 ], "windMode": [-1,-1,-1,-1] },
+				"up": { "texture": "#wood", "uv": [ 5.0, 4.5, 14.0, 13.0 ] },
+				"down": { "texture": "#wood", "uv": [ 4.5, 4.0, 13.5, 12.5 ], "windMode": [-1,-1,-1,-1] }
+			},
+			"children": [
+				{
+					"name": "hinge1",
+					"from": [ 1.0, -0.5, -0.5 ],
+					"to": [ 3.0, 0.5, 0.0 ],
+					"rotationOrigin": [ 1.0, 0.0, -1.0 ],
+					"faces": {
+						"north": { "texture": "#metal", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
+						"east": { "texture": "#metal", "uv": [ 0.0, 0.0, 0.5, 1.0 ] },
+						"south": { "texture": "#metal", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
+						"west": { "texture": "#metal", "uv": [ 0.0, 0.0, 0.5, 1.0 ] },
+						"up": { "texture": "#metal", "uv": [ 0.0, 0.0, 2.0, 0.5 ] },
+						"down": { "texture": "#metal", "uv": [ 0.0, 0.0, 2.0, 0.5 ] }
+					}
+				},
+				{
+					"name": "hinge2",
+					"from": [ 6.0, -0.5, -0.5 ],
+					"to": [ 8.0, 0.5, 0.0 ],
+					"rotationOrigin": [ 6.0, 0.0, -1.0 ],
+					"faces": {
+						"north": { "texture": "#metal", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
+						"east": { "texture": "#metal", "uv": [ 0.0, 0.0, 0.5, 1.0 ] },
+						"south": { "texture": "#metal", "uv": [ 0.0, 0.0, 2.0, 1.0 ] },
+						"west": { "texture": "#metal", "uv": [ 0.0, 0.0, 0.5, 1.0 ] },
+						"up": { "texture": "#metal", "uv": [ 0.0, 0.0, 2.0, 0.5 ] },
+						"down": { "texture": "#metal", "uv": [ 0.0, 0.0, 2.0, 0.5 ] }
+					}
+				},
+				{
+					"name": "clasp",
+					"from": [ 3.25, -1.0, 7.5 ],
+					"to": [ 5.75, 0.5, 9.0 ],
+					"rotationOrigin": [ 3.0, -1.0, 7.0 ],
+					"faces": {
+						"north": { "texture": "#metal", "uv": [ 0.0, 0.0, 2.5, 1.5 ] },
+						"east": { "texture": "#metal", "uv": [ 0.0, 0.0, 1.5, 1.5 ] },
+						"south": { "texture": "#metal", "uv": [ 0.0, 0.0, 2.5, 1.5 ] },
+						"west": { "texture": "#metal", "uv": [ 0.0, 0.0, 1.5, 1.5 ] },
+						"up": { "texture": "#metal", "uv": [ 0.0, 0.0, 2.5, 1.5 ] },
+						"down": { "texture": "#metal", "uv": [ 0.0, 0.0, 2.5, 1.5 ] }
+					}
+				}
+			]
+		}
+	]}

--- a/Lunchbox/code/block_behaviour/CollectableBehaviourLunchbox.cs
+++ b/Lunchbox/code/block_behaviour/CollectableBehaviourLunchbox.cs
@@ -1,9 +1,16 @@
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
 using Vintagestory.API.Common;
+using Vintagestory.API.Config;
 using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
 using Vintagestory.API.Util;
 using Vintagestory.GameContent;
+using static HarmonyLib.Code;
 
 #nullable disable
 
@@ -11,10 +18,30 @@ namespace Lunchbox;
 
 class CollectableBehaviorLunchbox : CollectibleBehaviorHeldBag, IHeldBag
 {
+    // Generic
     public List<ItemSlotBagContent> _slots;
+    public InventoryBase _inventory;
+    ItemLunchBox _lunchbox;
+
+    // Spoilage
+    private float _defaultPerishableFactor = 1.0f;
+    static private string LUNCHBOX_ATTRIBUTE = "lunchbox";
 
     public CollectableBehaviorLunchbox(CollectibleObject obj) : base(obj)
     {
+        _lunchbox = obj as ItemLunchBox;
+    }
+
+    public new void Store(ItemStack bagstack, ItemSlotBagContent slot)
+    {
+        base.Store(bagstack, slot);
+        AddLunchboxAttribute(slot?.Itemstack);
+    }
+
+    public override void GetHeldItemInfo(ItemSlot inSlot, StringBuilder dsc, IWorldAccessor world, bool withDebugInfo)
+    {
+        // This info technically lives on the Lunchbox but the order looks strange so we'll put it here
+        dsc.AppendLine(Lang.Get("Stored food perish speed: {0}x", Math.Round(_defaultPerishableFactor, 2)));
     }
 
     /*
@@ -23,6 +50,10 @@ class CollectableBehaviorLunchbox : CollectibleBehaviorHeldBag, IHeldBag
      */
     public new List<ItemSlotBagContent> GetOrCreateSlots(ItemStack bagstack, InventoryBase parentinv, int bagIndex, IWorldAccessor world)
     {
+        // If we don't assign this here Perish Mult won't work :(
+        // May work in some other hook but for now it lives here
+        _defaultPerishableFactor = _lunchbox?.Attributes?["defaultSpoilSpeedMult"].Exists == true ? _lunchbox.Attributes["defaultSpoilSpeedMult"].AsFloat() : _defaultPerishableFactor;
+
         var bagContents = new List<ItemSlotBagContent>();
 
         string bgcolhex = GetSlotBgColor(bagstack);
@@ -65,6 +96,7 @@ class CollectableBehaviorLunchbox : CollectibleBehaviorHeldBag, IHeldBag
 
                 while (bagContents.Count <= slotIndex) bagContents.Add(null);
                 bagContents[slotIndex] = slot;
+                AddLunchboxAttribute(slot.Itemstack); // Change
             }
         }
 
@@ -78,9 +110,59 @@ class CollectableBehaviorLunchbox : CollectibleBehaviorHeldBag, IHeldBag
          * There seems to be no way to register the lunchbox auto-eat functionality on server connection. 
          * The only place that seems doable is here when the inventory slots are created.
          */
-        var lunchbox = collObj as ItemLunchBox;
-        lunchbox?.ConfigureAutoEat(world, parentinv);
+        _lunchbox?.ConfigureAutoEat(world, parentinv);
+
+        /*
+         * Register Spoilage Rate Multiplier to the Inventory
+         */
+        if (HasSpoilageRateMul())
+        {
+            if (_inventory != null)
+            {
+                _inventory.OnAcquireTransitionSpeed -= Inventory_OnAcquireTransitionSpeed;
+            }
+
+            _inventory = parentinv;
+            _inventory.OnAcquireTransitionSpeed += Inventory_OnAcquireTransitionSpeed;
+        }
 
         return bagContents;
+    }
+
+    /**
+     * \brief Returns a transition speed modification.
+     */
+    private float Inventory_OnAcquireTransitionSpeed(EnumTransitionType transType, ItemStack stack, float baseMul)
+    {
+        // If it's invalid skip
+        if (transType != EnumTransitionType.Perish) return baseMul;
+        if (stack == null || stack.Collectible == null) return baseMul;
+
+        // If it's not in a Lunchbox skip
+        if (!stack.TempAttributes.GetBool(LUNCHBOX_ATTRIBUTE, false)) return baseMul;
+
+        // No support for per-food-category perish rate yet
+        return baseMul * _defaultPerishableFactor;
+    }
+
+    /**
+     * \brief Appends a temporary attribute to the provided item \a stack that it is stored in a lunchbox.
+     */
+    private void AddLunchboxAttribute(ItemStack stack)
+    {
+        /* 
+         * All backpacks share the same inventory
+         * We need to flag that this item we've added to the slot belongs to a Lunchbox
+         * Whether we tick for spoilage depends on if we have any Multipliers to apply
+         */
+        stack?.TempAttributes.SetBool(LUNCHBOX_ATTRIBUTE, HasSpoilageRateMul());
+    }
+
+    /**
+     * \brief Returns whether this has a spoilage rate multiplier or not.
+     */
+    private bool HasSpoilageRateMul()
+    {
+        return _defaultPerishableFactor != 1.0f;
     }
 }

--- a/Lunchbox/code/block_behaviour/CollectableBehaviourLunchbox.cs
+++ b/Lunchbox/code/block_behaviour/CollectableBehaviourLunchbox.cs
@@ -40,6 +40,11 @@ class CollectableBehaviorLunchbox : CollectibleBehaviorHeldBag, IHeldBag
 
     public override void GetHeldItemInfo(ItemSlot inSlot, StringBuilder dsc, IWorldAccessor world, bool withDebugInfo)
     {
+        // This value isn't being displayed to the user in the menu
+        // For some reason it isn't set properly in the constructor
+        // Quick Hack
+        _defaultPerishableFactor = _lunchbox?.Attributes?["defaultSpoilSpeedMult"].Exists == true ? _lunchbox.Attributes["defaultSpoilSpeedMult"].AsFloat() : _defaultPerishableFactor;
+
         // This info technically lives on the Lunchbox but the order looks strange so we'll put it here
         dsc.AppendLine(Lang.Get("Stored food perish speed: {0}x", Math.Round(_defaultPerishableFactor, 2)));
     }

--- a/Lunchbox/modinfo.json
+++ b/Lunchbox/modinfo.json
@@ -5,7 +5,7 @@
     "name": "Lunchbox",
     "authors": [ "azurempress" ],
     "description": "Adds a lunchbox storage container which automatically feeds the player when hungry.",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "dependencies": {
         "game": "1.21.0"
     },


### PR DESCRIPTION
Added a Cooler Lunchbox Item which behaves as a normal lunchbox, but also allows for a slower perish speed. 

Design is based on a wooden cooler. Recipe is based on an Icebox: https://en.wikipedia.org/wiki/Icebox

Recipe is moderately expensive to account for perish buff. 
Number of slots have not changed from the initial Lunchbox - we can make a more expensive bag with more slots / less restrictions.

Additional changes:
- Set the lunchbox slot color to be pink to differentiate from the mining bag
- English & JP languages added for Cooler